### PR TITLE
Cli Init command

### DIFF
--- a/application/package-lock.json
+++ b/application/package-lock.json
@@ -12,6 +12,8 @@
         "continuous-security": "build/continuous-security"
       },
       "devDependencies": {
+        "@inquirer/checkbox": "^1.3.2",
+        "@inquirer/select": "^1.2.2",
         "@types/dockerode": "^3.3.14",
         "@types/jest": "^29.2.6",
         "@types/lodash": "^4.14.191",
@@ -736,6 +738,83 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-1.3.2.tgz",
+      "integrity": "sha512-9ZhpEXiwlXAJ7KvUiDqIy9L4mayOGcP9aDRLT6eiwguuFW1gXQTspteIxk/b6QGger1UXJrtXQpPS7A+PGzVuA==",
+      "dev": true,
+      "dependencies": {
+        "@inquirer/core": "^2.2.0",
+        "@inquirer/type": "^1.1.0",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "figures": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-YcSAyRTEJTzitg3yzEGabz0Jwmi8iO9QiLeDVY8LQLzY9AsLouuGRvUZ2Savp1T7AAYCMqDFLQirzB+eSux2Vg==",
+      "dev": true,
+      "dependencies": {
+        "@inquirer/type": "^1.1.0",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "cli-spinners": "^2.8.0",
+        "cli-width": "^4.0.0",
+        "figures": "^3.2.0",
+        "mute-stream": "^1.0.0",
+        "run-async": "^3.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-1.2.2.tgz",
+      "integrity": "sha512-asiP4Ej4AR0uWsQt8/ajAtF5IjBuTZ/YQgn/Xk7kviWN/wuFfUBo0dYntr0/rSvhNyt0jY6/yDhMM6mSPFLHRg==",
+      "dev": true,
+      "dependencies": {
+        "@inquirer/core": "^2.2.0",
+        "@inquirer/type": "^1.1.0",
+        "ansi-escapes": "^4.3.2",
+        "chalk": "^4.1.2",
+        "figures": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.1.0.tgz",
+      "integrity": "sha512-XMaorygt2o/mXinZg/OOz6d3JKuV3o4jRc/3KDiVPeKLLkjiO4iJErbLKtKn+Od2ZC2lbiFQkrIuloVpEubisA==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.18.0"
+      }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -2438,6 +2517,27 @@
       "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
       "dev": true
     },
+    "node_modules/cli-spinners": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.0.tgz",
+      "integrity": "sha512-4/aL9X3Wh0yiMQlE+eeRhWP6vclO3QRtw1JHKIT0FFUs5FjpFmESqtMvYZ0+lbzBw900b95mS0hohy+qn2VK/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.0.0.tgz",
+      "integrity": "sha512-ZksGS2xpa/bYkNzN3BAw1wEjsLV/ZKOf/CCrJ/QOBsxx6fOARIkwTutxp1XIOIohi6HKmOFjMoK/XaqDVUpEEw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -3174,6 +3274,30 @@
       "dev": true,
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/figures": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/figures/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -4748,6 +4872,15 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
+    "node_modules/mute-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+      "dev": true,
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/nan": {
       "version": "2.17.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
@@ -5535,6 +5668,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/run-async": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
+      "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/run-parallel": {

--- a/application/package.json
+++ b/application/package.json
@@ -26,6 +26,8 @@
   },
   "private": false,
   "devDependencies": {
+    "@inquirer/checkbox": "^1.3.2",
+    "@inquirer/select": "^1.2.2",
     "@types/dockerode": "^3.3.14",
     "@types/jest": "^29.2.6",
     "@types/lodash": "^4.14.191",

--- a/application/src/Cli.ts
+++ b/application/src/Cli.ts
@@ -3,6 +3,7 @@ import {Command} from 'commander';
 import packageJson from '../package.json';
 
 import {ScanCommand} from "./Commands/Scan";
+import {InitialiseCommand} from "./Commands/Initialise";
 
 const program = new Command();
 
@@ -12,5 +13,6 @@ program.name('continuous-security')
   .showHelpAfterError(true);
 
 ScanCommand(program);
+InitialiseCommand(program);
 
 program.parse();

--- a/application/src/Cli.ts
+++ b/application/src/Cli.ts
@@ -1,32 +1,16 @@
-import {Command, InvalidArgumentError} from 'commander';
-
-import {Orchestrator} from './Orchestrator';
-import {Logger} from './Logger';
+import {Command} from 'commander';
 
 import packageJson from '../package.json';
 
-const program = new Command();
-const orchestrator = new Orchestrator(process.cwd());
-new Logger(orchestrator.emitter);
+import {ScanCommand} from "./Commands/Scan";
 
-const isValidReport = (input: unknown): input is 'markdown' | 'json' =>
-  typeof input === 'string' && ['markdown', 'json'].includes(input);
+const program = new Command();
 
 program.name('continuous-security')
   .description(packageJson.description)
   .version(packageJson.version)
   .showHelpAfterError(true);
 
-program.command('scan')
-  .description('Perform a scan')
-  .option('--ci', 'Use the CI logger for line by line output.')
-  .option('--report  <type>', 'The type of report you want the scan to produce.', 'markdown')
-  .action(async (options: { ci?: boolean, report?: string }) => {
-    if (!isValidReport(options.report))
-      throw new InvalidArgumentError('--report must be markdown or json');
-
-    await orchestrator.run();
-    await orchestrator.writeReport(process.cwd(), options.report);
-  });
+ScanCommand(program);
 
 program.parse();

--- a/application/src/Commands/Initialise.ts
+++ b/application/src/Commands/Initialise.ts
@@ -1,0 +1,54 @@
+import select from "@inquirer/select";
+import checkbox from "@inquirer/checkbox";
+import {Command, InvalidArgumentError} from "commander";
+import {stringify as YAMLStringify} from "yaml";
+import {writeFile} from 'fs/promises';
+import {resolve} from "path";
+
+import availableScanners from "../scanners.json";
+
+export const InitialiseCommand = (program: Command) => {
+  program.command('init')
+    .description('Initialise continuous security configuration')
+    .action(async () => {
+      console.log('Initialising new continuous security config.');
+      const format = await select({
+        message: 'Choose a configuration format.',
+        choices: [
+          {name: 'YAML', value: 'yaml'},
+          {name: 'JSON', value: 'json'},
+        ],
+      });
+
+      const choices = availableScanners.scanners.map(({name, description}) => ({
+        name: `${name}: ${description}`,
+        value: name,
+      }));
+
+      const chosenScanners = await checkbox({
+        message: 'Select the scanners you wish to use.',
+        choices,
+      });
+
+      if (!chosenScanners || chosenScanners.length === 0) throw new InvalidArgumentError('To initialise a project, you must select at least one scanner.');
+
+      const configuration = {scanners: chosenScanners.map(a => `@continuous-security/scanner-${a}`)};
+
+      switch (format) {
+        case 'json':
+          await writeFile(
+            resolve(process.cwd(), '.continuous-security.json'),
+            JSON.stringify(configuration, null, 2),
+          );
+          break;
+        case 'yaml':
+          await writeFile(
+            resolve(process.cwd(), '.continuous-security.yml'),
+            YAMLStringify(configuration),
+          );
+          break;
+      }
+
+      console.log("Success! Scan your project with continuous-security scan");
+    });
+}

--- a/application/src/Commands/Scan.ts
+++ b/application/src/Commands/Scan.ts
@@ -1,0 +1,23 @@
+import {Command, InvalidArgumentError} from "commander";
+import {Orchestrator} from "../Orchestrator";
+import {Logger} from "../Logger";
+
+const orchestrator = new Orchestrator(process.cwd());
+new Logger(orchestrator.emitter);
+
+const isValidReport = (input: unknown): input is 'markdown' | 'json' =>
+  typeof input === 'string' && ['markdown', 'json'].includes(input);
+
+export const ScanCommand = (program: Command) => {
+  program.command('scan')
+    .description('Perform a scan')
+    .option('--ci', 'Use the CI logger for line by line output.')
+    .option('--report  <type>', 'The type of report you want the scan to produce.', 'markdown')
+    .action(async (options: { ci?: boolean, report?: string }) => {
+      if (!isValidReport(options.report))
+        throw new InvalidArgumentError('--report must be markdown or json');
+
+      await orchestrator.run();
+      await orchestrator.writeReport(process.cwd(), options.report);
+    });
+}


### PR DESCRIPTION
*What?*

Add a new command `continuous-security init` that creates a config file after asking some questions.

*Why?*

This allows a developer to create an initial configuration file quickly and correctly.

*How?*

* Split cli commands out into separate files
* Add an `init` command to the cli.
* Using the [inquirer](https://github.com/SBoudrias/Inquirer.js/tree/master) libraries `select` and `checkbox` package, for UI elements on the command line.