### PR TITLE
CVE api integration

### DIFF
--- a/application/src/DataSources/CVE.test.ts
+++ b/application/src/DataSources/CVE.test.ts
@@ -1,0 +1,33 @@
+import axios from 'axios';
+import {CVE} from './CVE';
+import {CVEResponse} from '../../tests/fixtures/CVEResponse';
+
+jest.mock('axios', () => ({
+  get: jest.fn(),
+}));
+
+describe('a CVE security advisory', () => {
+  (axios.get as jest.Mock).mockResolvedValueOnce({data: CVEResponse});
+
+  let reference: ReportOutputIssueReference;
+
+  beforeAll(async () => {
+    reference = await (new CVE()).getById('CVE-2019-1010218');
+  });
+
+  test('has the correct label', () => {
+    expect(reference.label).toEqual('CVE-2019-1010218');
+  });
+
+  test('has the correct title', () => {
+    expect(reference.title).toEqual('CVE-2019-1010218');
+  });
+
+  test('has the correct description', () => {
+    expect(reference.description).toEqual('Cherokee Webserver Latest Cherokee Web server Upto Version 1.2.103 (Current stable) is affected by: Buffer Overflow - CWE-120. The impact is: Crash. The component is: Main cherokee command. The attack vector is: Overwrite argv[0] to an insane length with execl. The fixed version is: There\'s no fix yet.');
+  });
+
+  test('has the correct url', () => {
+    expect(reference.directLink).toEqual('https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-1010218');
+  });
+});

--- a/application/src/DataSources/CVE.ts
+++ b/application/src/DataSources/CVE.ts
@@ -1,0 +1,38 @@
+import axios from 'axios';
+
+export class CVE {
+  private apiUrl = 'https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=';
+  private viewVulnerabilityUrl = 'https://cve.mitre.org/cgi-bin/cvename.cgi?name=';
+
+  private async getData(id: string): Promise<CVEAPIResponse> {
+    const response = await axios.get<CVEAPIResponse>(this.apiUrl + id);
+    return response.data;
+  }
+
+  async getById(id: string): Promise<ReportOutputIssueReference> {
+    try {
+      const response = await this.getData(id);
+      const cveData = response.vulnerabilities[0].cve;
+
+      const aliases = cveData.weaknesses
+        .map(({description}) => description)
+        .flat()
+        .map(({value}) => value);
+
+      return {
+        label: id,
+        title: id,
+        description: cveData.descriptions.find(d => d.lang === 'en')?.value,
+        directLink: this.viewVulnerabilityUrl + id,
+        dataSourceSpecific: {
+          cve: {
+            aliases,
+            severity: cveData.metrics?.cvssMetricV31?.[0]?.cvssData?.baseSeverity?.toLowerCase() as ReportOutputIssueReference['dataSourceSpecific']['osv']['severity'] ?? 'unknown',
+          },
+        },
+      };
+    } catch (e) {
+      throw new Error(`failed to get id ${id}`);
+    }
+  }
+}

--- a/application/src/Report.test.ts
+++ b/application/src/Report.test.ts
@@ -185,6 +185,20 @@ describe('producing a report', () => {
           }
         },
         {
+          "label": "CVE-2023-2251",
+          "title": "CVE-2023-2251",
+          "description": "Uncaught Exception in GitHub repository eemeli/yaml prior to 2.0.0-5.",
+          "directLink": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2251",
+          "dataSourceSpecific": {
+            "cve": {
+              "aliases": [
+                "CWE-248"
+              ],
+              "severity": "high"
+            }
+          }
+        },
+        {
           "label": "CWE-248",
           "title": "Uncaught Exception",
           "description": "An exception is thrown from a function, but it is not caught.",
@@ -374,7 +388,7 @@ test-issue-description
 
 ##### References
 
-[GHSA-f9xv-q969-pqx4](https://osv.dev/vulnerability/GHSA-f9xv-q969-pqx4) | [CWE-1004](https://cwe.mitre.org/data/definitions/1004.html) | [CWE-248](https://cwe.mitre.org/data/definitions/248.html)
+[GHSA-f9xv-q969-pqx4](https://osv.dev/vulnerability/GHSA-f9xv-q969-pqx4) | [CWE-1004](https://cwe.mitre.org/data/definitions/1004.html) | [CVE-2023-2251](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-2251) | [CWE-248](https://cwe.mitre.org/data/definitions/248.html)
 
 ### Unknown Severity
 

--- a/application/src/Report.ts
+++ b/application/src/Report.ts
@@ -1,6 +1,7 @@
 import {template, TemplateExecutor} from 'lodash';
 import {basename} from 'path';
 import BaseTemplate from './assets/report.template.md';
+import {CVE} from './DataSources/CVE';
 import {CWE} from './DataSources/CWE';
 import {OSV} from './DataSources/OSV';
 import {Emitter} from './Emitter';
@@ -8,6 +9,7 @@ import {Emitter} from './Emitter';
 export class Report {
   private readonly template: TemplateExecutor;
   private reports: Array<ScanReport> = [];
+  private cveDataset: CVE = new CVE();
   private cweDataset: CWE = new CWE();
   private osvDataset: OSV = new OSV();
   private emitter: Emitter;
@@ -51,6 +53,8 @@ export class Report {
 
         if (slug.indexOf('cwe') === 0) {
           expandedReferences[ref] = this.cweDataset.getById(ref.toUpperCase());
+        } else if (slug.indexOf('cve') === 0) {
+          expandedReferences[ref] = await this.cveDataset.getById(ref.toUpperCase());
         } else {
           try {
             expandedReferences[ref] = await this.osvDataset.getById(ref);

--- a/application/tests/fixtures/CVEResponse.ts
+++ b/application/tests/fixtures/CVEResponse.ts
@@ -1,0 +1,95 @@
+export const CVEResponse = {
+  resultsPerPage: 1,
+  startIndex: 0,
+  totalResults: 1,
+  format: 'NVD_CVE',
+  version: '2.0',
+  timestamp: '2023-06-30T23:34:19.163',
+  vulnerabilities: [{
+    cve: {
+      id: 'CVE-2019-1010218',
+      sourceIdentifier: 'josh@bress.net',
+      published: '2019-07-22T18:15:10.917',
+      lastModified: '2020-09-30T13:40:18.163',
+      vulnStatus: 'Analyzed',
+      descriptions: [{
+        lang: 'en',
+        value: 'Cherokee Webserver Latest Cherokee Web server Upto Version 1.2.103 (Current stable) is affected by: Buffer Overflow - CWE-120. The impact is: Crash. The component is: Main cherokee command. The attack vector is: Overwrite argv[0] to an insane length with execl. The fixed version is: There\'s no fix yet.'
+      }, {
+        lang: 'es',
+        value: 'El servidor web de Cherokee más reciente de Cherokee Webserver Hasta Versión 1.2.103 (estable actual) está afectado por: Desbordamiento de Búfer - CWE-120. El impacto es: Bloqueo. El componente es: Comando cherokee principal. El vector de ataque es: Sobrescribir argv[0] en una longitud no sana con execl. La versión corregida es: no hay ninguna solución aún.'
+      }],
+      metrics: {
+        cvssMetricV31: [{
+          source: 'nvd@nist.gov',
+          type: 'Primary',
+          cvssData: {
+            version: '3.1',
+            vectorString: 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H',
+            attackVector: 'NETWORK',
+            attackComplexity: 'LOW',
+            privilegesRequired: 'NONE',
+            userInteraction: 'NONE',
+            scope: 'UNCHANGED',
+            confidentialityImpact: 'NONE',
+            integrityImpact: 'NONE',
+            availabilityImpact: 'HIGH',
+            baseScore: 7.5,
+            baseSeverity: 'HIGH'
+          },
+          exploitabilityScore: 3.9,
+          impactScore: 3.6
+        }],
+        cvssMetricV2: [{
+          source: 'nvd@nist.gov',
+          type: 'Primary',
+          cvssData: {
+            version: '2.0',
+            vectorString: 'AV:N/AC:L/Au:N/C:N/I:N/A:P',
+            accessVector: 'NETWORK',
+            accessComplexity: 'LOW',
+            authentication: 'NONE',
+            confidentialityImpact: 'NONE',
+            integrityImpact: 'NONE',
+            availabilityImpact: 'PARTIAL',
+            baseScore: 5.0
+          },
+          baseSeverity: 'MEDIUM',
+          exploitabilityScore: 10.0,
+          impactScore: 2.9,
+          acInsufInfo: false,
+          obtainAllPrivilege: false,
+          obtainUserPrivilege: false,
+          obtainOtherPrivilege: false,
+          userInteractionRequired: false
+        }]
+      },
+      weaknesses: [{
+        source: 'nvd@nist.gov',
+        type: 'Primary',
+        description: [{lang: 'en', value: 'CWE-787'}]
+      }, {
+        source: 'josh@bress.net',
+        type: 'Secondary',
+        description: [{lang: 'en', value: 'CWE-120'}]
+      }],
+      configurations: [{
+        nodes: [{
+          operator: 'OR',
+          negate: false,
+          cpeMatch: [{
+            vulnerable: true,
+            criteria: 'cpe:2.3:a:cherokee-project:cherokee_web_server:*:*:*:*:*:*:*:*',
+            versionEndIncluding: '1.2.103',
+            matchCriteriaId: 'DCE1E311-F9E5-4752-9F51-D5DA78B7BBFA'
+          }]
+        }]
+      }],
+      references: [{
+        url: 'https://i.imgur.com/PWCCyir.png',
+        source: 'josh@bress.net',
+        tags: ['Exploit', 'Third Party Advisory']
+      }]
+    }
+  }]
+};

--- a/application/types.d.ts
+++ b/application/types.d.ts
@@ -46,6 +46,10 @@ type ReportOutputIssueReference = {
       aliases: Array<string>;
       severity?: 'info' | 'low' | 'moderate' | 'high' | 'critical' | 'unknown';
     };
+    cve?: {
+      aliases: Array<string>;
+      severity?: 'info' | 'low' | 'moderate' | 'high' | 'critical' | 'unknown';
+    };
     cwe?: {
       extendedDescription: string;
       background: string;

--- a/application/types.d.ts
+++ b/application/types.d.ts
@@ -105,3 +105,28 @@ type OSVAPIResponse = {
     score: string;
   }>
 }
+
+type CVEAPIResponse = {
+  vulnerabilities: Array<{
+    cve: {
+      id: string;
+      descriptions: Array<{
+        lang: string;
+        value: string;
+      }>;
+      metrics: {
+        cvssMetricV31: Array<{
+          cvssData: {
+            baseSeverity: string;
+          };
+        }>;
+      };
+      weaknesses: Array<{
+        description: Array<{
+          lang: string;
+          value: string;
+        }>;
+      }>;
+    }
+  }>;
+}


### PR DESCRIPTION
*What?*

Adds support for CVE reference expansion.

*Why?*

So valid CVE references can be linked to from inside reports.

*How?*

Essentially a duplicate of the `OSV` dataset, but using the [NIST [NATIONAL VULNERABILITY DATABASE](https://nvd.nist.gov/)](https://nvd.nist.gov/) API.