### PR TITLE
fix: suppress XML errors and Cancellable Promise exception

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,6 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           npm ci
-          npm run build
           npm publish
 
   enumerate-scanners:

--- a/application/src/DataSources/CWE.ts
+++ b/application/src/DataSources/CWE.ts
@@ -12,7 +12,9 @@ export class CWEDoesNotExist extends Error {
 
 export class CWE {
   private data = (new DOMParser({
-    errorHandler: undefined,
+    errorHandler: (level: string, msg: any) => {
+      return {};
+    },
   })).parseFromString(CWEDataset);
 
   getById(id: string): ReportOutputIssueReference {

--- a/application/tsconfig.json
+++ b/application/tsconfig.json
@@ -1,9 +1,11 @@
 {
   "compilerOptions": {
-    "esModuleInterop": true,
-    "resolveJsonModule": true,
     "allowJs": true,
+    "esModuleInterop": true,
+    "moduleResolution": "node",
     "outDir": "build",
+    "resolveJsonModule": true,
+    "target": "es6",
     "types": ["node", "jest"]
   },
   "include": ["./src/**/*.ts", "./types.d.ts", "./types.scanner.d.ts"],


### PR DESCRIPTION
*What?*

* Suppress XML errors from the CWE dataset module when encountering simple issues parsing XML documents.
* Target es6 to avoid the Cancellable Promise exception thrown when running `continuous-security init` command.

*Why?*

To fix errors running the application post-compilation.