### PR TITLE
fix: do not scan node_modules folder with js-x-ray

### DIFF
--- a/examples/nodejs/main.js
+++ b/examples/nodejs/main.js
@@ -3,3 +3,5 @@ require("crypto")
   .createHash("md5")
   .update("Man oh man do I love node!")
   .digest("hex");
+
+"".match(/`(?:\\[\s\S]|\${(?:[^{}]|{(?:[^{}]|{[^}]*})*})*}|(?!\${)[^\\`])*`/g);

--- a/scanners/javascript-js-x-ray/src/assets/scan.mjs
+++ b/scanners/javascript-js-x-ray/src/assets/scan.mjs
@@ -44,6 +44,8 @@ Array.prototype.groupBy = function (field) {
 };
 
 const analysis = getAllFiles()
+  // Filter out node_modules/
+  .filter(path => path.indexOf('node_modules/') === -1)
   // Filter out non-javascript files
   .filter(path => lookup(path) === 'application/javascript')
   // Filter out files without .js extention

--- a/scanners/javascript-js-x-ray/test/integration.test.ts
+++ b/scanners/javascript-js-x-ray/test/integration.test.ts
@@ -17,18 +17,8 @@ setupIntegrationTests(
         type: 'code smell',
         extracts: expect.arrayContaining([
           {
-            path: 'node_modules/squirrelly/dist/browser/squirrelly.dev.js',
-            lines: ['141'],
-            language: 'javascript',
-          },
-          {
-            path: 'node_modules/squirrelly/dist/squirrelly.cjs.js',
-            lines: ['167'],
-            language: 'javascript',
-          },
-          {
-            path: 'node_modules/squirrelly/dist/squirrelly.es.js',
-            lines: ['163'],
+            path: 'main.js',
+            lines: ['7'],
             language: 'javascript',
           },
         ]),


### PR DESCRIPTION
*What?*

Disable scanning the `node_modules/` folder with js-x-ray.

*Why?*

Quite often, legitimate modules like Babel will use techniques that may be detected as problematic when they are by design and rarely used outside of development dependencies. A follow-up to this could be to read the `package.json` file and test all production dependencies.