### PR TITLE
fix: test scanners with current head

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -74,6 +74,10 @@ jobs:
         working-directory: application/
       - run: continuous-security scan
         working-directory: application/
+      - uses: actions/upload-artifact@v3
+        with:
+          name: application-${{ github.ref_name }}-build
+          path: application/build/
 
   enumerate-scanners:
     name: scanner / enumerate

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -72,7 +72,7 @@ jobs:
         working-directory: application/
       - uses: actions/upload-artifact@v3
         with:
-          name: ${{ github.run_id }}-application
+          name: application
           path: |
             application/
             !application/node_modules
@@ -126,7 +126,7 @@ jobs:
         working-directory: scanners/${{ matrix.scanner }}/
       - uses: actions/upload-artifact@v3
         with:
-          name: ${{ github.run_id }}-${{ matrix.scanner }}
+          name: ${{ matrix.scanner }}
           path: |
             scanners/${{ matrix.scanner }}/
             !scanners/${{ matrix.scanner }}/node_modules
@@ -148,15 +148,9 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           path: artefacts/
-      - run: |
-          for D in "$(ls -1 artefacts/ | grep '${{ github.run_id }}-*')"; do
-            cd artefacts/$D
-            npm link
-            cd ../..
-          done
-      - run: DEBUG=true continuous-security scan || (cat report.md >> $GITHUB_STEP_SUMMARY)
-        working-directory: application/
-
+      - run: tree artefacts/
+#      - run: DEBUG=true continuous-security scan || (cat report.md >> $GITHUB_STEP_SUMMARY)
+#        working-directory: application/
 
   scanner-check:
     name: scanner / scan / ${{ matrix.scanner }}
@@ -178,12 +172,6 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           path: artefacts/
-      - run: |
-          for D in "$(ls -1 artefacts/ | grep '${{ github.run_id }}-*')"; do
-            cd artefacts/$D
-            npm link
-            cd ../..
-          done
-      - run: DEBUG=true continuous-security scan || (cat report.md >> $GITHUB_STEP_SUMMARY)
-        working-directory: scanners/${{ matrix.scanner }}/
-
+      - run: tree artefacts/
+#      - run: DEBUG=true continuous-security scan || (cat report.md >> $GITHUB_STEP_SUMMARY)
+#        working-directory: scanners/${{ matrix.scanner }}/

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -149,7 +149,7 @@ jobs:
         with:
           path: artefacts/
       - run: |
-          for D in (ls -1 artefacts/ | grep '${{ github.run_id }}-*'); do
+          for D in "$(ls -1 artefacts/ | grep '${{ github.run_id }}-*')"; do
             cd $D
             npm link
             cd ..
@@ -180,7 +180,7 @@ jobs:
         with:
           path: artefacts/
       - run: |
-          for D in (ls -1 artefacts/ | grep '${{ github.run_id }}-*'); do
+          for D in "$(ls -1 artefacts/ | grep '${{ github.run_id }}-*')"; do
             cd $D
             npm link
             cd ..

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -144,7 +144,7 @@ jobs:
           node-version: '18'
           registry-url: 'https://registry.npmjs.org'
           cache: npm
-          cache-dependency-path: scanners/${{ matrix.scanner }}/package-lock.json
+          cache-dependency-path: application/package-lock.json
       - uses: actions/download-artifact@v3
         with:
           path: artefacts/

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -150,11 +150,10 @@ jobs:
           path: artefacts/
       - run: |
           for D in "$(ls -1 artefacts/ | grep '${{ github.run_id }}-*')"; do
-            cd $D
+            cd artefacts/$D
             npm link
-            cd ..
+            cd ../..
           done
-        working-directory: artefacts/
       - run: DEBUG=true continuous-security scan || (cat report.md >> $GITHUB_STEP_SUMMARY)
         working-directory: application/
 
@@ -181,11 +180,10 @@ jobs:
           path: artefacts/
       - run: |
           for D in "$(ls -1 artefacts/ | grep '${{ github.run_id }}-*')"; do
-            cd $D
+            cd artefacts/$D
             npm link
-            cd ..
+            cd ../..
           done
-        working-directory: artefacts/
       - run: DEBUG=true continuous-security scan || (cat report.md >> $GITHUB_STEP_SUMMARY)
         working-directory: scanners/${{ matrix.scanner }}/
 

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -88,7 +88,7 @@ jobs:
   scanners:
     name: scanner / ${{ matrix.scanner }}
     runs-on: ubuntu-latest
-    needs: [ application, enumerate-scanners ]
+    needs: [ enumerate-scanners ]
     strategy:
       matrix:
         scanner: ${{ fromJSON(needs.enumerate-scanners.outputs.scanners) }}

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -92,7 +92,7 @@ jobs:
   scanners:
     name: scanner / ${{ matrix.scanner }}
     runs-on: ubuntu-latest
-    needs: [ enumerate-scanners ]
+    needs: [ application, enumerate-scanners ]
     strategy:
       matrix:
         scanner: ${{ fromJSON(needs.enumerate-scanners.outputs.scanners) }}
@@ -124,9 +124,12 @@ jobs:
       - name: integration test
         run: npm run test:integration --if-present
         working-directory: scanners/${{ matrix.scanner }}/
-      - run: |
-          npm i -g @continuous-security/application
-          continuous-security scan
+      - uses: actions/download-artifact@v3
+        with:
+          name: application-${{ github.ref_name }}-build
+      - run: npm link
+        working-directory: application/
+      - run: continuous-security scan
         working-directory: scanners/${{ matrix.scanner }}/
       - run: npm run build
         working-directory: scanners/${{ matrix.scanner }}/

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -70,14 +70,10 @@ jobs:
         working-directory: application/
       - run: npm run build
         working-directory: application/
-      - run: npm link
-        working-directory: application/
-      - run: continuous-security scan
-        working-directory: application/
       - uses: actions/upload-artifact@v3
         with:
-          name: application-${{ github.run_id }}-build
-          path: application/build/
+          name: ${{ github.run_id }}-application
+          path: application/
 
   enumerate-scanners:
     name: scanner / enumerate
@@ -124,15 +120,68 @@ jobs:
       - name: integration test
         run: npm run test:integration --if-present
         working-directory: scanners/${{ matrix.scanner }}/
-      - uses: actions/download-artifact@v3
-        with:
-          name: application-${{ github.run_id }}-build
-          path: application/build
-      - run: ls -al
-        working-directory: application/
-      - run: npm link
-        working-directory: application/
-      - run: continuous-security scan
-        working-directory: scanners/${{ matrix.scanner }}/
       - run: npm run build
         working-directory: scanners/${{ matrix.scanner }}/
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ github.run_id }}-${{ matrix.scanner }}
+          path: scanners/${{ matrix.scanner }}/
+
+  application-check:
+    name: application / scan
+    runs-on: ubuntu-latest
+    needs: [ application, scanners ]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          registry-url: 'https://registry.npmjs.org'
+          cache: npm
+          cache-dependency-path: scanners/${{ matrix.scanner }}/package-lock.json
+      - uses: actions/download-artifact@v3
+        with:
+          path: artefacts/
+      - run: |
+          for D in (ls -1 artefacts/ | grep '${{ github.run_id }}-*'); do
+            cd $D
+            npm link
+            cd ..
+          done
+        working-directory: artefacts/
+      - run: DEBUG=true continuous-security scan || (cat report.md >> $GITHUB_STEP_SUMMARY)
+        working-directory: application/
+
+
+  scanner-check:
+    name: scanner / scan / ${{ matrix.scanner }}
+    runs-on: ubuntu-latest
+    needs: [ application, scanners, enumerate-scanners ]
+    strategy:
+      matrix:
+        scanner: ${{ fromJSON(needs.enumerate-scanners.outputs.scanners) }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          registry-url: 'https://registry.npmjs.org'
+          cache: npm
+          cache-dependency-path: scanners/${{ matrix.scanner }}/package-lock.json
+      - uses: actions/download-artifact@v3
+        with:
+          path: artefacts/
+      - run: |
+          for D in (ls -1 artefacts/ | grep '${{ github.run_id }}-*'); do
+            cd $D
+            npm link
+            cd ..
+          done
+        working-directory: artefacts/
+      - run: DEBUG=true continuous-security scan || (cat report.md >> $GITHUB_STEP_SUMMARY)
+        working-directory: scanners/${{ matrix.scanner }}/
+

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -73,7 +73,9 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: ${{ github.run_id }}-application
-          path: application/
+          path: |
+            application/
+            !application/node_modules
 
   enumerate-scanners:
     name: scanner / enumerate
@@ -125,7 +127,9 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: ${{ github.run_id }}-${{ matrix.scanner }}
-          path: scanners/${{ matrix.scanner }}/
+          path: |
+            scanners/${{ matrix.scanner }}/
+            !scanners/${{ matrix.scanner }}/node_modules
 
   application-check:
     name: application / scan

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -148,9 +148,20 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           path: artefacts/
-      - run: tree artefacts/
-#      - run: DEBUG=true continuous-security scan || (cat report.md >> $GITHUB_STEP_SUMMARY)
-#        working-directory: application/
+      - run: |
+          for D in $(ls -1 artefacts/); do
+            cd artefacts/$D
+            npm link
+            cd ../..
+          done
+      - run: DEBUG=true continuous-security scan
+        id: scan
+        working-directory: application/
+        continue-on-error: true
+      - if: steps.scan.outcome != 'success'
+        run: |
+          cat report.md >> $GITHUB_STEP_SUMMARY
+          exit 1
 
   scanner-check:
     name: scanner / scan / ${{ matrix.scanner }}
@@ -172,6 +183,17 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           path: artefacts/
-      - run: tree artefacts/
-#      - run: DEBUG=true continuous-security scan || (cat report.md >> $GITHUB_STEP_SUMMARY)
-#        working-directory: scanners/${{ matrix.scanner }}/
+      - run: |
+          for D in $(ls -1 artefacts/); do
+            cd artefacts/$D
+            npm link
+            cd ../..
+          done
+      - run: DEBUG=true continuous-security scan
+        id: scan
+        working-directory: scanners/${{ matrix.scanner }}/
+        continue-on-error: true
+      - if: steps.scan.outcome != 'success'
+        run: |
+          cat report.md >> $GITHUB_STEP_SUMMARY
+          exit 1

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -127,6 +127,7 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: application-${{ github.run_id }}-build
+          path: application/build
       - run: ls -al
         working-directory: application/
       - run: npm link

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -127,6 +127,8 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: application-${{ github.run_id }}-build
+      - run: ls -al
+        working-directory: application/
       - run: npm link
         working-directory: application/
       - run: continuous-security scan

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -76,7 +76,7 @@ jobs:
         working-directory: application/
       - uses: actions/upload-artifact@v3
         with:
-          name: application-${{ github.ref_name }}-build
+          name: application-${{ github.run_id }}-build
           path: application/build/
 
   enumerate-scanners:
@@ -126,7 +126,7 @@ jobs:
         working-directory: scanners/${{ matrix.scanner }}/
       - uses: actions/download-artifact@v3
         with:
-          name: application-${{ github.ref_name }}-build
+          name: application-${{ github.run_id }}-build
       - run: npm link
         working-directory: application/
       - run: continuous-security scan

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -11,17 +11,23 @@ questions about the scanners you wish to use.
 
 ```typescript title="configuration.d.ts"
 type ConfigurationFile = {
+  ignore?: Array<string>;
   scanners: Array<string | {
     name: string;
     with?: Record<string, string>;
-  }>
+  }>;
 }
 ```
 
 ## Example JavaScript Project
 
 ```yaml title=".continuous-security.yml file for a JavaScript project"
+ignore:
+  - node_modules/
+  - build/
+  - dist/
 scanners:
+  - "@continuous-security/scanner-bearer"
   - "@continuous-security/scanner-javascript-js-x-ray"
   - "@continuous-security/scanner-javascript-njsscan"
   - "@continuous-security/scanner-javascript-npm-audit"
@@ -34,6 +40,7 @@ scanners:
 
 ```yaml title=".continuous-security.yml file for a Ruby project"
 scanners:
+  - "@continuous-security/scanner-bearer"
   - "@continuous-security/scanner-ruby-bundle-audit"
   - name: "@continuous-security/scanner-zed-attack-proxy"
     with:

--- a/documentation/docs/scanners/bearer.md
+++ b/documentation/docs/scanners/bearer.md
@@ -11,7 +11,7 @@ No configuration is required for this scanner.
 `.continuous-security.yml`
 ```yaml
 scanners:
-  - @continuous-security/scanner-bearer
+  - "@continuous-security/scanner-bearer"
 ```
 
 

--- a/documentation/docs/scanners/javascript-js-x-ray.md
+++ b/documentation/docs/scanners/javascript-js-x-ray.md
@@ -11,7 +11,7 @@ No configuration is required for this scanner.
 `.continuous-security.yml`
 ```yaml
 scanners:
-  - @continuous-security/scanner-javascript-js-x-ray
+  - "@continuous-security/scanner-javascript-js-x-ray"
 ```
 
 ## Attribution

--- a/documentation/docs/scanners/javascript-njsscan.md
+++ b/documentation/docs/scanners/javascript-njsscan.md
@@ -11,7 +11,7 @@ No configuration is required for this scanner.
 `.continuous-security.yml`
 ```yaml
 scanners:
-  - @continuous-security/scanner-javascript-njsscan
+  - "@continuous-security/scanner-javascript-njsscan"
 ```
 
 ## Attribution

--- a/documentation/docs/scanners/javascript-npm-audit.md
+++ b/documentation/docs/scanners/javascript-npm-audit.md
@@ -11,5 +11,5 @@ No configuration is required for this scanner.
 `.continuous-security.yml`
 ```yaml
 scanners:
-  - @continuous-security/scanner-javascript-npm-audit
+  - "@continuous-security/scanner-javascript-npm-audit"
 ```

--- a/documentation/docs/scanners/python-bandit.md
+++ b/documentation/docs/scanners/python-bandit.md
@@ -11,7 +11,7 @@ No configuration is required for this scanner.
 `.continuous-security.yml`
 ```yaml
 scanners:
-  - @continuous-security/scanner-python-bandit
+  - "@continuous-security/scanner-python-bandit"
 ```
 
 ## Attribution

--- a/documentation/docs/scanners/python-pip-audit.md
+++ b/documentation/docs/scanners/python-pip-audit.md
@@ -11,7 +11,7 @@ No configuration is required for this scanner.
 `.continuous-security.yml`
 ```yaml
 scanners:
-  - @continuous-security/scanner-python-pip-audit
+  - "@continuous-security/scanner-python-pip-audit"
 ```
 
 

--- a/documentation/docs/scanners/ruby-bundle-audit.md
+++ b/documentation/docs/scanners/ruby-bundle-audit.md
@@ -11,7 +11,7 @@ No configuration is required for this scanner.
 `.continuous-security.yml`
 ```yaml
 scanners:
-  - @continuous-security/scanner-ruby-bundle-audit
+  - "@continuous-security/scanner-ruby-bundle-audit"
 ```
 
 ## Attribution

--- a/documentation/docs/scanners/zed-attack-proxy.md
+++ b/documentation/docs/scanners/zed-attack-proxy.md
@@ -11,7 +11,7 @@ This scanner requires a target URL to scan and can be configured as follows:
 `.continuous-security.yml`
 ```yaml
 scanners:
-  - name: @continuous-security/scanner-zed-attack-proxy
+  - name: "@continuous-security/scanner-zed-attack-proxy"
     with:
       target: http://example.com
 ```
@@ -39,7 +39,7 @@ Use this configuration
 
 ```yaml
 scanners:
-  - name: @continuous-security/scanner-zed-attack-proxy
+  - name: "@continuous-security/scanner-zed-attack-proxy"
     with:
       target: http://172.17.0.1:3000
 ```

--- a/scanners/bearer/README.md
+++ b/scanners/bearer/README.md
@@ -11,7 +11,7 @@ No configuration is required for this scanner.
 `.continuous-security.yml`
 ```yaml
 scanners:
-  - @continuous-security/scanner-bearer
+  - "@continuous-security/scanner-bearer"
 ```
 
 

--- a/scanners/javascript-js-x-ray/README.md
+++ b/scanners/javascript-js-x-ray/README.md
@@ -11,7 +11,7 @@ No configuration is required for this scanner.
 `.continuous-security.yml`
 ```yaml
 scanners:
-  - @continuous-security/scanner-javascript-js-x-ray
+  - "@continuous-security/scanner-javascript-js-x-ray"
 ```
 
 ## Attribution

--- a/scanners/javascript-njsscan/README.md
+++ b/scanners/javascript-njsscan/README.md
@@ -11,7 +11,7 @@ No configuration is required for this scanner.
 `.continuous-security.yml`
 ```yaml
 scanners:
-  - @continuous-security/scanner-javascript-njsscan
+  - "@continuous-security/scanner-javascript-njsscan"
 ```
 
 ## Attribution

--- a/scanners/javascript-npm-audit/README.md
+++ b/scanners/javascript-npm-audit/README.md
@@ -11,7 +11,7 @@ No configuration is required for this scanner.
 `.continuous-security.yml`
 ```yaml
 scanners:
-  - @continuous-security/scanner-javascript-npm-audit
+  - "@continuous-security/scanner-javascript-npm-audit"
 ```
 
 ## Attribution

--- a/scanners/python-bandit/README.md
+++ b/scanners/python-bandit/README.md
@@ -11,7 +11,7 @@ No configuration is required for this scanner.
 `.continuous-security.yml`
 ```yaml
 scanners:
-  - @continuous-security/scanner-python-bandit
+  - "@continuous-security/scanner-python-bandit"
 ```
 
 

--- a/scanners/python-pip-audit/README.md
+++ b/scanners/python-pip-audit/README.md
@@ -11,7 +11,7 @@ No configuration is required for this scanner.
 `.continuous-security.yml`
 ```yaml
 scanners:
-  - @continuous-security/scanner-python-pip-audit
+  - "@continuous-security/scanner-python-pip-audit"
 ```
 
 

--- a/scanners/ruby-bundle-audit/README.md
+++ b/scanners/ruby-bundle-audit/README.md
@@ -11,7 +11,7 @@ No configuration is required for this scanner.
 `.continuous-security.yml`
 ```yaml
 scanners:
-  - @continuous-security/scanner-ruby-bundle-audit
+  - "@continuous-security/scanner-ruby-bundle-audit"
 ```
 
 

--- a/scanners/zed-attack-proxy/README.md
+++ b/scanners/zed-attack-proxy/README.md
@@ -11,7 +11,7 @@ This scanner requires a target URL to scan and can be configured as follows:
 `.continuous-security.yml`
 ```yaml
 scanners:
-  - name: @continuous-security/scanner-zed-attack-proxy
+  - name: "@continuous-security/scanner-zed-attack-proxy"
     with:
       target: http://example.com
 ```
@@ -39,7 +39,7 @@ Use this configuration
 
 ```yaml
 scanners:
-  - name: @continuous-security/scanner-zed-attack-proxy
+  - name: "@continuous-security/scanner-zed-attack-proxy"
     with:
       target: http://172.17.0.1:3000
 ```


### PR DESCRIPTION
## What?

When running a self-check, ensure that the application and scanners are tested with the current development build of continuous-security.

## Why?

* Acts as a final test of the build
* Ensures the application and scanner code is checked for vulnerabilities